### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/config/model-binding.php
+++ b/config/model-binding.php
@@ -473,5 +473,21 @@ return [
         return NextDeveloper\Stay\Database\Models\StayHotel::findByRef($value);
 },
 
+'stayroomtype' => function ($value) {
+        return NextDeveloper\Stay\Database\Models\StayRoomType::findByRef($value);
+},
+
+'stayroom' => function ($value) {
+        return NextDeveloper\Stay\Database\Models\StayRoom::findByRef($value);
+},
+
+'stayreservation' => function ($value) {
+        return NextDeveloper\Stay\Database\Models\StayReservation::findByRef($value);
+},
+
+'stayhotel' => function ($value) {
+        return NextDeveloper\Stay\Database\Models\StayHotel::findByRef($value);
+},
+
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 ];

--- a/src/Database/Filters/HotelsQueryFilter.php
+++ b/src/Database/Filters/HotelsQueryFilter.php
@@ -152,4 +152,5 @@ class HotelsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/ReservationsQueryFilter.php
+++ b/src/Database/Filters/ReservationsQueryFilter.php
@@ -115,4 +115,5 @@ class ReservationsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/RoomTypesQueryFilter.php
+++ b/src/Database/Filters/RoomTypesQueryFilter.php
@@ -28,6 +28,11 @@ class RoomTypesQueryFilter extends AbstractQueryFilter
         return $this->builder->where('description', 'like', '%' . $value . '%');
     }
 
+    public function isPublic()
+    {
+        return $this->builder->where('is_public', true);
+    }
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -77,6 +82,7 @@ class RoomTypesQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n
+
 
 
 

--- a/src/Database/Filters/RoomsQueryFilter.php
+++ b/src/Database/Filters/RoomsQueryFilter.php
@@ -23,6 +23,11 @@ class RoomsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('name', 'like', '%' . $value . '%');
     }
 
+    public function isPublic()
+    {
+        return $this->builder->where('is_public', true);
+    }
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -72,6 +77,7 @@ class RoomsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n
+
 
 
 

--- a/src/Database/Models/Hotels.php
+++ b/src/Database/Models/Hotels.php
@@ -195,4 +195,5 @@ class Hotels extends Model
 
 
 
+
 }

--- a/src/Database/Models/Reservations.php
+++ b/src/Database/Models/Reservations.php
@@ -184,4 +184,5 @@ class Reservations extends Model
 
 
 
+
 }

--- a/src/Database/Models/RoomTypes.php
+++ b/src/Database/Models/RoomTypes.php
@@ -26,6 +26,7 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property \Carbon\Carbon $deleted_at
+ * @property boolean $is_public
  */
 class RoomTypes extends Model
 {
@@ -50,6 +51,7 @@ class RoomTypes extends Model
             'facilities',
             'price',
             'common_currency_id',
+            'is_public',
     ];
 
     /**
@@ -81,6 +83,7 @@ class RoomTypes extends Model
     'created_at' => 'datetime',
     'updated_at' => 'datetime',
     'deleted_at' => 'datetime',
+    'is_public' => 'boolean',
     ];
 
     /**
@@ -142,6 +145,7 @@ class RoomTypes extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n\n\n\n\n
+
 
 
 

--- a/src/Database/Models/Rooms.php
+++ b/src/Database/Models/Rooms.php
@@ -24,6 +24,7 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property \Carbon\Carbon $deleted_at
+ * @property boolean $is_public
  */
 class Rooms extends Model
 {
@@ -46,6 +47,7 @@ class Rooms extends Model
             'features',
             'stay_hotels_id',
             'stay_room_type_id',
+            'is_public',
     ];
 
     /**
@@ -76,6 +78,7 @@ class Rooms extends Model
     'created_at' => 'datetime',
     'updated_at' => 'datetime',
     'deleted_at' => 'datetime',
+    'is_public' => 'boolean',
     ];
 
     /**
@@ -137,6 +140,7 @@ class Rooms extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Requests/RoomTypes/RoomTypesCreateRequest.php
+++ b/src/Http/Requests/RoomTypes/RoomTypesCreateRequest.php
@@ -19,6 +19,7 @@ class RoomTypesCreateRequest extends AbstractFormRequest
         'facilities' => 'nullable',
         'price' => 'nullable',
         'common_currency_id' => 'nullable|exists:common_currencies,uuid|uuid',
+        'is_public' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n

--- a/src/Http/Requests/RoomTypes/RoomTypesUpdateRequest.php
+++ b/src/Http/Requests/RoomTypes/RoomTypesUpdateRequest.php
@@ -19,6 +19,7 @@ class RoomTypesUpdateRequest extends AbstractFormRequest
         'facilities' => 'nullable',
         'price' => 'nullable',
         'common_currency_id' => 'nullable|exists:common_currencies,uuid|uuid',
+        'is_public' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n

--- a/src/Http/Requests/Rooms/RoomsCreateRequest.php
+++ b/src/Http/Requests/Rooms/RoomsCreateRequest.php
@@ -17,6 +17,7 @@ class RoomsCreateRequest extends AbstractFormRequest
         'features' => 'nullable',
         'stay_hotels_id' => 'nullable|exists:stay_hotels,uuid|uuid',
         'stay_room_type_id' => 'nullable|exists:stay_room_types,uuid|uuid',
+        'is_public' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n

--- a/src/Http/Requests/Rooms/RoomsUpdateRequest.php
+++ b/src/Http/Requests/Rooms/RoomsUpdateRequest.php
@@ -17,6 +17,7 @@ class RoomsUpdateRequest extends AbstractFormRequest
         'features' => 'nullable',
         'stay_hotels_id' => 'nullable|exists:stay_hotels,uuid|uuid',
         'stay_room_type_id' => 'nullable|exists:stay_room_types,uuid|uuid',
+        'is_public' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n

--- a/src/Http/Transformers/AbstractTransformers/AbstractHotelsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractHotelsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Stay\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Stay\Database\Models\Hotels;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class HotelsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,19 +33,34 @@ class AbstractHotelsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Hotels $model
      *
      * @return array
      */
     public function transform(Hotels $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                    $commonCityId = \NextDeveloper\Commons\Database\Models\Cities::where('id', $model->common_city_id)->first();
-                    $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
-                    $foregroundMediaId = \NextDeveloper\Commons\Database\Models\Media::where('id', $model->foreground_media_id)->first();
-                    $backgroundMediaId = \NextDeveloper\Commons\Database\Models\Media::where('id', $model->background_media_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                                                            $commonCityId = \NextDeveloper\Commons\Database\Models\Cities::where('id', $model->common_city_id)->first();
+                                                            $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
+                                                            $foregroundMediaId = \NextDeveloper\Commons\Database\Models\Media::where('id', $model->foreground_media_id)->first();
+                                                            $backgroundMediaId = \NextDeveloper\Commons\Database\Models\Media::where('id', $model->background_media_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -52,7 +86,91 @@ class AbstractHotelsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Hotels $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Hotels $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Hotels $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Hotels $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Hotels $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Hotels $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Hotels $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Hotels $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Hotels $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractReservationsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractReservationsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Stay\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Stay\Database\Models\Reservations;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class ReservationsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,17 +33,32 @@ class AbstractReservationsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Reservations $model
      *
      * @return array
      */
     public function transform(Reservations $model)
     {
-                        $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
-                    $stayRoomId = \NextDeveloper\Stay\Database\Models\Rooms::where('id', $model->stay_room_id)->first();
-                    $stayRoomTypeId = \NextDeveloper\Stay\Database\Models\RoomTypes::where('id', $model->stay_room_type_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
+                                                            $stayRoomId = \NextDeveloper\Stay\Database\Models\Rooms::where('id', $model->stay_room_id)->first();
+                                                            $stayRoomTypeId = \NextDeveloper\Stay\Database\Models\RoomTypes::where('id', $model->stay_room_type_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -41,7 +75,91 @@ class AbstractReservationsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Reservations $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Reservations $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Reservations $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Reservations $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Reservations $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Reservations $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Reservations $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Reservations $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Reservations $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractRoomTypesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractRoomTypesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Stay\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Stay\Database\Models\RoomTypes;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class RoomTypesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractRoomTypesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param RoomTypes $model
      *
      * @return array
      */
     public function transform(RoomTypes $model)
     {
-                        $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-        
+                                                $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -35,11 +69,96 @@ class AbstractRoomTypesTransformer extends AbstractTransformer
             'created_at'  =>  $model->created_at,
             'updated_at'  =>  $model->updated_at,
             'deleted_at'  =>  $model->deleted_at,
+            'is_public'  =>  $model->is_public,
             ]
         );
     }
 
+    public function includeStates(RoomTypes $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(RoomTypes $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(RoomTypes $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(RoomTypes $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(RoomTypes $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(RoomTypes $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(RoomTypes $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(RoomTypes $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(RoomTypes $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractRoomsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractRoomsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Stay\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Stay\Database\Models\Rooms;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class RoomsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractRoomsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Rooms $model
      *
      * @return array
      */
     public function transform(Rooms $model)
     {
-                        $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
-                    $stayRoomTypeId = \NextDeveloper\Stay\Database\Models\RoomTypes::where('id', $model->stay_room_type_id)->first();
-        
+                                                $stayHotelsId = \NextDeveloper\Stay\Database\Models\Hotels::where('id', $model->stay_hotels_id)->first();
+                                                            $stayRoomTypeId = \NextDeveloper\Stay\Database\Models\RoomTypes::where('id', $model->stay_room_type_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -33,11 +67,96 @@ class AbstractRoomsTransformer extends AbstractTransformer
             'created_at'  =>  $model->created_at,
             'updated_at'  =>  $model->updated_at,
             'deleted_at'  =>  $model->deleted_at,
+            'is_public'  =>  $model->is_public,
             ]
         );
     }
 
+    public function includeStates(Rooms $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Rooms $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Rooms $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Rooms $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Rooms $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Rooms $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Rooms $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Rooms $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Rooms $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -2,45 +2,10 @@
 
 Route::prefix('stay')->group(
     function () {
-        Route::prefix('rooms')->group(
-            function () {
-                Route::get('/', 'Rooms\RoomsController@index');
-
-                Route::get('{stay_rooms}/tags ', 'Rooms\RoomsController@tags');
-                Route::post('{stay_rooms}/tags ', 'Rooms\RoomsController@saveTags');
-                Route::get('{stay_rooms}/addresses ', 'Rooms\RoomsController@addresses');
-                Route::post('{stay_rooms}/addresses ', 'Rooms\RoomsController@saveAddresses');
-
-                Route::get('/{stay_rooms}/{subObjects}', 'Rooms\RoomsController@relatedObjects');
-                Route::get('/{stay_rooms}', 'Rooms\RoomsController@show');
-
-                Route::post('/', 'Rooms\RoomsController@store');
-                Route::patch('/{stay_rooms}', 'Rooms\RoomsController@update');
-                Route::delete('/{stay_rooms}', 'Rooms\RoomsController@destroy');
-            }
-        );
-
-        Route::prefix('reservations')->group(
-            function () {
-                Route::get('/', 'Reservations\ReservationsController@index');
-
-                Route::get('{stay_reservations}/tags ', 'Reservations\ReservationsController@tags');
-                Route::post('{stay_reservations}/tags ', 'Reservations\ReservationsController@saveTags');
-                Route::get('{stay_reservations}/addresses ', 'Reservations\ReservationsController@addresses');
-                Route::post('{stay_reservations}/addresses ', 'Reservations\ReservationsController@saveAddresses');
-
-                Route::get('/{stay_reservations}/{subObjects}', 'Reservations\ReservationsController@relatedObjects');
-                Route::get('/{stay_reservations}', 'Reservations\ReservationsController@show');
-
-                Route::post('/', 'Reservations\ReservationsController@store');
-                Route::patch('/{stay_reservations}', 'Reservations\ReservationsController@update');
-                Route::delete('/{stay_reservations}', 'Reservations\ReservationsController@destroy');
-            }
-        );
-
         Route::prefix('room-types')->group(
             function () {
                 Route::get('/', 'RoomTypes\RoomTypesController@index');
+                Route::get('/actions', 'RoomTypes\RoomTypesController@getActions');
 
                 Route::get('{stay_room_types}/tags ', 'RoomTypes\RoomTypesController@tags');
                 Route::post('{stay_room_types}/tags ', 'RoomTypes\RoomTypesController@saveTags');
@@ -51,14 +16,59 @@ Route::prefix('stay')->group(
                 Route::get('/{stay_room_types}', 'RoomTypes\RoomTypesController@show');
 
                 Route::post('/', 'RoomTypes\RoomTypesController@store');
+                Route::post('/{stay_room_types}/do/{action}', 'RoomTypes\RoomTypesController@doAction');
+
                 Route::patch('/{stay_room_types}', 'RoomTypes\RoomTypesController@update');
                 Route::delete('/{stay_room_types}', 'RoomTypes\RoomTypesController@destroy');
+            }
+        );
+
+        Route::prefix('rooms')->group(
+            function () {
+                Route::get('/', 'Rooms\RoomsController@index');
+                Route::get('/actions', 'Rooms\RoomsController@getActions');
+
+                Route::get('{stay_rooms}/tags ', 'Rooms\RoomsController@tags');
+                Route::post('{stay_rooms}/tags ', 'Rooms\RoomsController@saveTags');
+                Route::get('{stay_rooms}/addresses ', 'Rooms\RoomsController@addresses');
+                Route::post('{stay_rooms}/addresses ', 'Rooms\RoomsController@saveAddresses');
+
+                Route::get('/{stay_rooms}/{subObjects}', 'Rooms\RoomsController@relatedObjects');
+                Route::get('/{stay_rooms}', 'Rooms\RoomsController@show');
+
+                Route::post('/', 'Rooms\RoomsController@store');
+                Route::post('/{stay_rooms}/do/{action}', 'Rooms\RoomsController@doAction');
+
+                Route::patch('/{stay_rooms}', 'Rooms\RoomsController@update');
+                Route::delete('/{stay_rooms}', 'Rooms\RoomsController@destroy');
+            }
+        );
+
+        Route::prefix('reservations')->group(
+            function () {
+                Route::get('/', 'Reservations\ReservationsController@index');
+                Route::get('/actions', 'Reservations\ReservationsController@getActions');
+
+                Route::get('{stay_reservations}/tags ', 'Reservations\ReservationsController@tags');
+                Route::post('{stay_reservations}/tags ', 'Reservations\ReservationsController@saveTags');
+                Route::get('{stay_reservations}/addresses ', 'Reservations\ReservationsController@addresses');
+                Route::post('{stay_reservations}/addresses ', 'Reservations\ReservationsController@saveAddresses');
+
+                Route::get('/{stay_reservations}/{subObjects}', 'Reservations\ReservationsController@relatedObjects');
+                Route::get('/{stay_reservations}', 'Reservations\ReservationsController@show');
+
+                Route::post('/', 'Reservations\ReservationsController@store');
+                Route::post('/{stay_reservations}/do/{action}', 'Reservations\ReservationsController@doAction');
+
+                Route::patch('/{stay_reservations}', 'Reservations\ReservationsController@update');
+                Route::delete('/{stay_reservations}', 'Reservations\ReservationsController@destroy');
             }
         );
 
         Route::prefix('hotels')->group(
             function () {
                 Route::get('/', 'Hotels\HotelsController@index');
+                Route::get('/actions', 'Hotels\HotelsController@getActions');
 
                 Route::get('{stay_hotels}/tags ', 'Hotels\HotelsController@tags');
                 Route::post('{stay_hotels}/tags ', 'Hotels\HotelsController@saveTags');
@@ -69,6 +79,8 @@ Route::prefix('stay')->group(
                 Route::get('/{stay_hotels}', 'Hotels\HotelsController@show');
 
                 Route::post('/', 'Hotels\HotelsController@store');
+                Route::post('/{stay_hotels}/do/{action}', 'Hotels\HotelsController@doAction');
+
                 Route::patch('/{stay_hotels}', 'Hotels\HotelsController@update');
                 Route::delete('/{stay_hotels}', 'Hotels\HotelsController@destroy');
             }
@@ -206,8 +218,13 @@ Route::prefix('stay')->group(
 
 
 
+
+
+
+
     }
 );
+
 
 
 


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.